### PR TITLE
allow release-date and release-versions to be null

### DIFF
--- a/lib/frontmatter-linter.js
+++ b/lib/frontmatter-linter.js
@@ -62,17 +62,15 @@ module.exports = class FrontmatterLinter {
         },
       },
       'release-date': {
-        type: 'date',
+        type: ['date', 'null'],
         required: true,
-        allowEmpty: false,
         messages: {
           type: 'must be a date formatted YYYY-MM-DD',
         },
       },
       'release-versions': {
-        type: 'object',
+        type: ['object', 'null'],
         required: true,
-        allowEmpty: true,
         conform(packages) {
           for (const p in packages) {
             if (!semver.valid(packages[p])) {


### PR DESCRIPTION
This allows empty release-dates and release-versions (which we can change when we have finished backfilling) and then once they are specified it will enforce the type 👍 

i.e. this is how you implement "allows null". The "required" and "allowEmpty" are both quite buggy in revalidator so we have to do it a different way 👍 